### PR TITLE
Update slides01.html

### DIFF
--- a/Data-Management-Seminar/slides/slides01.html
+++ b/Data-Management-Seminar/slides/slides01.html
@@ -5148,7 +5148,7 @@ Pseudo-pipeline file – used to simulate a software pipe
               <div style="font-size: 70%; line-height: 200%; line-height: 135%;">
                 <ul>
                   <li><a href="https://osp.od.nih.gov/policies/artificial-intelligence/" target="_blank">NIH AI Guidelines</a></li>
-                  <li><a href="https://bioethics.miami.edu/index.html" target="_blank">UM AI Research Guide</a><br></li>
+                  <li><a href="https://guides.library.miami.edu/ai" target="_blank">UM AI Research Guide</a><br></li>
                 </ul>
               </div>               
             </div><br><br>


### PR DESCRIPTION
Old link linked to "https://bioethics.miami.edu/index.html". Updated to change to https://guides.library.miami.edu/ai.